### PR TITLE
Bundle exec the `rails server`

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -4,4 +4,4 @@
 nginx &
 
 # start rails listening on 0.0.0.0:$PORT
-rails server -b 0.0.0.0 -p $PORT
+bundle exec rails server -b 0.0.0.0 -p $PORT


### PR DESCRIPTION
It may have been due to how I bundle install (using --path
vendor/bundle --deployment) but the `rails` command was not being found.

This would be the idiomatic usage regardless.
