### PR TITLE
nginx should only serve compiled assets

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -25,7 +25,7 @@ http {
 
     root /app/public;
 
-    location ^~ /assets/ {
+    location ~ /assets\/application-.* {
       gzip_static on;
       expires max;
       add_header Cache-Control public;


### PR DESCRIPTION
The previous location matcher was a little too aggressive, matching every `/assets` path. In development mode many `/assets/...` requests generate content on the fly, so this configuration was causing 404s.

The new form should only match filenames for compiled assets, such as `application-c32f7b43ef73cc850befd1856d8b4e067c4ed248e90b4ea4793762b7bb4642f2.js` for example.
